### PR TITLE
Adding get methods to gyro sensor

### DIFF
--- a/src/sensors/gyro_sensor.rs
+++ b/src/sensors/gyro_sensor.rs
@@ -37,20 +37,26 @@ impl GyroSensor {
     /// Calibration ???
     pub const MODE_GYRO_CAL: &'static str = "GYRO-CAL";
 
+    /// Rotational Speed (2nd axis)
+    pub const MODE_TILT_RATE: &'static str = "TILT-RATE";
+
+    /// Angle (2nd axis)
+    pub const MODE_TILT_ANG: &'static str = "TILT-ANG";
+
     sensor!();
 
     /// Angle
-    pub fn set_mode_col_ang(&self) -> Ev3Result<()> {
+    pub fn set_mode_gyro_ang(&self) -> Ev3Result<()> {
         self.set_mode(Self::MODE_GYRO_ANG)
     }
 
     /// Rotational Speed
-    pub fn set_mode_col_rate(&self) -> Ev3Result<()> {
+    pub fn set_mode_gyro_rate(&self) -> Ev3Result<()> {
         self.set_mode(Self::MODE_GYRO_RATE)
     }
 
     /// Raw sensor value ???
-    pub fn set_mode_col_fas(&self) -> Ev3Result<()> {
+    pub fn set_mode_gyro_fas(&self) -> Ev3Result<()> {
         self.set_mode(Self::MODE_GYRO_FAS)
     }
 
@@ -64,31 +70,40 @@ impl GyroSensor {
         self.set_mode(Self::MODE_GYRO_CAL)
     }
 
+    /// Calibration ???
+    pub fn set_mode_tilt_rate(&self) -> Ev3Result<()> {
+        self.set_mode(Self::MODE_TILT_RATE)
+    }
+
+    /// Calibration ???
+    pub fn set_mode_tilt_ang(&self) -> Ev3Result<()> {
+        self.set_mode(Self::MODE_TILT_ANG)
+    }
+
     /// Gets the angle, ranging from -32768 to 32767
     /// Fails if it has been set in the wrong mode
     pub fn get_angle(&self) -> Ev3Result<i32> {
-        if self.get_mode()? == GyroSensor::MODE_GYRO_G_AND_A
-            || self.get_mode()? == GyroSensor::MODE_GYRO_ANG
-        {
-            return self.get_value0();
+        match self.get_mode()?.as_ref() {
+            GyroSensor::MODE_GYRO_G_AND_A => self.get_value0(),
+            GyroSensor::MODE_GYRO_ANG => self.get_value0(),
+            mode => Ev3Result::Err(Ev3Error::InternalError {
+                msg: format!("Cannot get angle while in {} mode", mode),
+                // Returns error
+            }),
         }
-        Ev3Result::Err(Ev3Error::InternalError {
-            msg: format!("Cannot get angle while in {}", self.get_mode()?),
-        })
     }
 
     /// Gets the rotational speed value, ranging from -440 to 440
     /// Fails is it has been set in the wrong mode:
     /// for example, fails if we ask for rotational speed while in MODE_GYRO_ANG mode
     pub fn get_rotational_speed(&self) -> Ev3Result<i32> {
-        if self.get_mode()? == GyroSensor::MODE_GYRO_RATE {
-            return self.get_value0();
-        } else if self.get_mode()? == GyroSensor::MODE_GYRO_G_AND_A {
-            return self.get_value1();
+        match self.get_mode()?.as_ref() {
+            GyroSensor::MODE_GYRO_RATE => self.get_value0(),
+            GyroSensor::MODE_GYRO_G_AND_A => self.get_value1(),
+            mode => Ev3Result::Err(Ev3Error::InternalError {
+                msg: format!("Cannot get rotational speed while in {} mode", mode),
+                // Returns error
+            }),
         }
-
-        Ev3Result::Err(Ev3Error::InternalError {
-            msg: format!("Cannot get rotational speed while in {}", self.get_mode()?),
-        })
     }
 }

--- a/src/sensors/gyro_sensor.rs
+++ b/src/sensors/gyro_sensor.rs
@@ -10,11 +10,8 @@ pub struct GyroSensor {
 }
 
 impl GyroSensor {
-
     fn new(driver: Driver) -> Self {
-        Self {
-            driver,
-        }
+        Self { driver }
     }
 
     findable!(
@@ -65,5 +62,33 @@ impl GyroSensor {
     /// Calibration ???
     pub fn set_mode_gyro_cal(&self) -> Ev3Result<()> {
         self.set_mode(Self::MODE_GYRO_CAL)
+    }
+
+    /// Gets the angle, ranging from -32768 to 32767
+    /// Fails if it has been set in the wrong mode
+    pub fn get_angle(&self) -> Ev3Result<i32> {
+        if self.get_mode()? == GyroSensor::MODE_GYRO_G_AND_A
+            || self.get_mode()? == GyroSensor::MODE_GYRO_ANG
+        {
+            return self.get_value0();
+        }
+        Ev3Result::Err(Ev3Error::InternalError {
+            msg: format!("Cannot get angle while in {}", self.get_mode()?),
+        })
+    }
+
+    /// Gets the rotational speed value, ranging from -440 to 440
+    /// Fails is it has been set in the wrong mode:
+    /// for example, fails if we ask for rotational speed while in MODE_GYRO_ANG mode
+    pub fn get_rotational_speed(&self) -> Ev3Result<i32> {
+        if self.get_mode()? == GyroSensor::MODE_GYRO_RATE {
+            return self.get_value0();
+        } else if self.get_mode()? == GyroSensor::MODE_GYRO_G_AND_A {
+            return self.get_value1();
+        }
+
+        Ev3Result::Err(Ev3Error::InternalError {
+            msg: format!("Cannot get rotational speed while in {}", self.get_mode()?),
+        })
     }
 }


### PR DESCRIPTION
Hi!
This is my first contribution in Rust language.

I noticed that gyro_sensors.rs didn't have any get method.
I added two methods:
- get_angle
- get_rotational_speed
I don't know if there are any naming conventions for these methods I should have respected.

These methods willingly fail if the sensor is in the wrong mode, for instance, if we try to access rotational speed while we're in angle-only mode.
I found the details about this [here](https://docs.ev3dev.org/projects/lego-linux-drivers/en/ev3dev-stretch/sensor_data.html?highlight=gyro#lego-ev3-gyro-modes)

The code compiles successfully, but I'm still quite new to Rust language and I didn't test it.
Do you have any preferred test procedure I can follow in this repo?
Also, according to the docs, my file still lacks getter methods while in TILT-RATE, TILT-ANGLE, GYRO-CAL(no details in docs) and GYRO-FAS modes.