### PR TITLE
Fixed Framebuffer Errors causing Stack overflows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ impl From<std::num::ParseIntError> for Ev3Error {
 impl From<framebuffer::FramebufferError> for Ev3Error {
     fn from(err: framebuffer::FramebufferError) -> Self {
         Ev3Error::InternalError {
-            msg: format!("{}", err),
+            msg: format!("{}", err.details),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,7 +54,7 @@ impl From<std::num::ParseIntError> for Ev3Error {
 impl From<framebuffer::FramebufferError> for Ev3Error {
     fn from(err: framebuffer::FramebufferError) -> Self {
         Ev3Error::InternalError {
-            msg: format!("{}", err.details),
+            msg: format!("{:?}", err),
         }
     }
 }


### PR DESCRIPTION
 Calling Screen::new() on non ev3 device was causing stack overflows instead of returning an Error.
It seems to happen because FramebufferError doesn't implement Display but gets formatted with a "{}", but I don't understand why this would not be caught by the compiler.
But switching to using "{:?}" or printing err.details fixes the Problem 