### PR TITLE
Fix UltrasonicSensor::get_distance_inches() description

### DIFF
--- a/src/sensors/ultrasonic_sensor.rs
+++ b/src/sensors/ultrasonic_sensor.rs
@@ -100,7 +100,7 @@ impl UltrasonicSensor {
         Ok((self.get_value0()? as f32) * scale)
     }
 
-    /// Measurement of the distance detected by the sensor, in centimeters.
+    /// Measurement of the distance detected by the sensor, in inches.
     pub fn get_distance_inches(&self) -> Ev3Result<f32> {
         let scale_field = self.in_scale.get();
         let scale = match scale_field {


### PR DESCRIPTION
The description of `get_distance_inches()` says: *Measurement of the distance detected by the sensor, in **centimeters**.*