### PR TITLE
Support for playing multiple WAV files at once

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -145,6 +145,7 @@ pub fn tone_sequence(sequence: &[(f32, i32, i32)]) -> Ev3Result<Child> {
 pub fn play(wav_file: &str) -> Ev3Result<Child> {
     Ok(Command::new("/usr/bin/aplay")
         .arg("-q")
+        .arg("-Dplug:dmix")
         .arg(wav_file)
         .stdout(Stdio::null())
         .spawn()?)
@@ -159,6 +160,7 @@ pub fn speak(text: &str) -> Ev3Result<Child> {
 
     Ok(Command::new("/usr/bin/aplay")
         .arg("-q")
+        .arg("-Dplug:dmix")
         .stdin(espeak.stdout.ok_or(Ev3Error::InternalError {
             msg: "`espeak` pipe to `aplay` could not be created!".to_owned(),
         })?)


### PR DESCRIPTION
Multiple WAV files can play at the same time if you add `-Dplug:dmix` to `aplay`.